### PR TITLE
2020-11-27 Update configuration file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Types of changes
 - Fixed for any bug fixes.
 - Security in case of vulnerabilities.
 
+## [0.0.4-alpha] - 2020.11.28
+
+### Added
+- .cwd property to core_entities.CoreConfig()
+
+### Changed
+- Default core configuration file location moved to root of working directory
+- rename: eggbot.json <---> eggbot_core.json
+- Adjusted setup.py entry point to use __main__.py
+- Updated `package` for Makefile to move configs in with .zip properly
+
+### Deprecated
+- .abs_path property for core_entities.CoreConfig()
+  - Was referencing config files, turns out that's bad. No need for this.
+
 ## [0.0.3-alpha] - 2020.11.27
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/eggbot/config/*.json

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,12 @@ test: ## Run all tests found in the /tests directory.
 	python -m unittest discover -s tests
 
 package: clean-build ## Creates a package for testing
+	mkdir vendors
 	mkdir dist
-	pip install -r requirements.txt -t ./dist
+	pip install -r requirements.txt -t ./vendors
+	cp -r vendors/* ./dist/
 	cp -r ./src/eggbot ./dist
+	cp -r ./config/ ./dist/
 	mv ./dist/eggbot/__main__.py ./dist/main.py
 	test -f ./src/eggbot/.env && cp ./src/eggbot/.env ./dist/.env
 	(cd ./dist && zip -r ../artifact.zip .)

--- a/change_log_historic.md
+++ b/change_log_historic.md
@@ -1,6 +1,6 @@
 # This log was retired on 2020.11.24
 
-## New log is found at `changelog.md`
+# New log is found here: [CHANGELOG.md](CHANGELOG.md)
 
 ##### Change Log v0.6.9 - Fickled Egg - Bot Guard v1.0.0
 

--- a/config/eggbot_core.json
+++ b/config/eggbot_core.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.0.3-alpha",
+    "version": "0.0.4-alpha",
     "version_name": "Project Eggbot",
     "owner_id": ""
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*names, **kwargs):
 
 setup(
     name='Egg_Bot_Preocts',
-    version='0.0.3',
+    version='0.0.4',
     license='GNU General Public License',
     description='A module based Discord bot written in Python',
     author='Preocts',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'start-eggbot = eggbot.eggbot_core:main',
+            'start-eggbot = eggbot.__main__:main',
         ]
     },
     include_package_data=True

--- a/src/eggbot/core_entities.py
+++ b/src/eggbot/core_entities.py
@@ -4,9 +4,10 @@ Author  : Preocts, preocts@preocts.com
 Discord : Preocts#8196
 Git Repo: https://github.com/Preocts/Egg_Bot
 """
-import os
 import json
+import os
 import logging
+import pathlib
 import typing
 
 import dotenv
@@ -21,7 +22,8 @@ class CoreConfig(object):
 
     def __init__(self, **kwargs):
         self.__abs_path = f'{os.path.sep}'.join(
-            __file__.split(os.path.sep)[0:-1]) + "/"
+            __file__.split(os.path.sep)[0:-1])
+        self.__cwd = os.getcwd()
         self.__config = {}
 
     @property
@@ -29,10 +31,14 @@ class CoreConfig(object):
         return self.__abs_path
 
     @property
+    def cwd(self) -> str:
+        return self.__cwd
+
+    @property
     def config(self) -> dict:
         return dict(self.__config)
 
-    def load(self, filepath: str = 'config/eggbot.json',
+    def load(self, filepath: str = './config/eggbot_core.json',
              abs_path: bool = False) -> bool:
         """ Loads a config json
 
@@ -44,7 +50,9 @@ class CoreConfig(object):
                 relative to this module
         """
         self.__config = {}
-        path = filepath if abs_path else ''.join([self.abs_path, filepath])
+        rel_path = pathlib.Path(self.cwd).joinpath(filepath)
+        path = filepath if abs_path else rel_path.resolve()
+
         try:
             with open(path, 'r') as input_file:
                 self.__config = json.loads(input_file.read())
@@ -66,7 +74,7 @@ class CoreConfig(object):
 
         return True
 
-    def save(self, filepath: str = 'config/eggbot.json',
+    def save(self, filepath: str = './config/eggbot_core.json',
              abs_path: bool = False) -> bool:
         """ Saves a config json
 
@@ -79,7 +87,8 @@ class CoreConfig(object):
                 absolute path. Otherwise the path is considered
                 relative to this module
         """
-        path = filepath if abs_path else ''.join([self.abs_path, filepath])
+        rel_path = pathlib.Path(self.cwd).joinpath(filepath)
+        path = filepath if abs_path else rel_path.resolve()
         try:
             with open(path, 'w') as out_file:
                 out_file.write(json.dumps(self.__config, indent=4))

--- a/tests/test_core_entities.py
+++ b/tests/test_core_entities.py
@@ -1,4 +1,5 @@
 """ Test core entity objects """
+import os
 import pathlib
 import random
 import unittest
@@ -20,6 +21,11 @@ class TestCoreConfig(unittest.TestCase):
         self.assertTrue(config.abs_path.startswith(compare_path[0]))
         self.assertIn(config.abs_path, compare_path)
 
+    def test_cwd(self):
+        config = core_entities.CoreConfig()
+        self.assertIsInstance(config.cwd, str)
+        self.assertEqual(config.cwd, os.getcwd())
+
     def test_load(self):
         config = core_entities.CoreConfig()
 
@@ -29,7 +35,7 @@ class TestCoreConfig(unittest.TestCase):
         self.assertFalse(config.config)
 
         # Valid relative but invalid JSON
-        config.load('egg_bot.py')
+        config.load('README.md')
         self.assertIsInstance(config.config, dict)
         self.assertFalse(config.config)
 
@@ -69,7 +75,7 @@ class TestCoreConfig(unittest.TestCase):
 
     def test_save(self):
         args_list = [
-            ('/config/eggbot.json', False),
+            (),
             (pathlib.Path('./tests/files/mock_config.json').absolute(), True)
         ]
         random.seed()

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,44 @@
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+=                               Active                                 -
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+=                               Future                                 -
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+[_] Replace os with Pathlib
+[_] Version bumping script to capture updates 
+    - setup.py 
+    -./config/eggbot_core.json
+[_] README.md for configuration folder
+[_] Load/Save configuration should raise if error
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+=                              Complete                                -
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+2020-11-27 Configuration location:
+
+Configuration files are currently nested in with the module directories. 
+These should be at the top level of the project. This will provide
+
+- Visibility
+- Reliable path for accessing
+- Backup processes
+
+Acceptance Criteria:
+
+[x] Configurations are stored in the ./ of the working directory.
+    - ./config, Core configurations
+    - ./config/modules, Module level configuration
+[x] core_entities config loader can find these files
+[x] `pip install .` can find those files
+    - MANIFEST.in - Empty
+[x] `pip install -e .` can find those files
+    - MANIFEST.in - Empty
+[x] Files are copied into ./dist on `make package`
+    - Makefile - Done
+    - Does this only move the eggbot directory or are we pulling the
+      src directory as well?  - Yes
+[x] All unit tests pass


### PR DESCRIPTION
## [0.0.4-alpha] - 2020.11.28

### Added
- .cwd property to core_entities.CoreConfig()

### Changed
- Default core configuration file location moved to root of working directory
- rename: eggbot.json <---> eggbot_core.json
- Adjusted setup.py entry point to use __main__.py
- Updated `package` for Makefile to move configs in with .zip properly

### Deprecated
- .abs_path property for core_entities.CoreConfig()
  - Was referencing config files, turns out that's bad. No need for this.